### PR TITLE
Replace SSH-style git repo refs with git://

### DIFF
--- a/omnibus-ansible-dk/config/software/jq.rb
+++ b/omnibus-ansible-dk/config/software/jq.rb
@@ -1,7 +1,7 @@
 name "jq"
 default_version "master"
 relative_path "jq"
-source git: "git@github.com:stedolan/jq.git"
+source git: "git://github.com/stedolan/jq.git"
 
 dependency "libtool"
 dependency "make"

--- a/omnibus-ansible-dk/config/software/kitchen-ansible.rb
+++ b/omnibus-ansible-dk/config/software/kitchen-ansible.rb
@@ -2,7 +2,7 @@ name "kitchen-ansible"
 default_version "master"
 relative_path "kitchen-ansible"
 
-source git: "git@github.com:neillturner/kitchen-ansible.git"
+source git: "git://github.com/neillturner/kitchen-ansible.git"
 
 if windows?
   dependency "ruby-windows"

--- a/omnibus-ansible-dk/config/software/kitchen-ec2.rb
+++ b/omnibus-ansible-dk/config/software/kitchen-ec2.rb
@@ -2,7 +2,7 @@ name "kitchen-ec2"
 default_version "master"
 relative_path "kitchen-ec2"
 
-source git: "git@github.com:test-kitchen/kitchen-ec2.git"
+source git: "git://github.com/test-kitchen/kitchen-ec2.git"
 
 if windows?
   dependency "ruby-windows"


### PR DESCRIPTION
Fixes bad clones on ubuntu, which seems to insist on trying to authenticate, which is probably more correct behavior
