### PR TITLE
Add support for molecule

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The ansible tool itself.
 
 #### ansible-lint
 
-[Ansible-lint](https://github.com/willthames/ansible-lint) linter for ansible.
+[Ansible-lint](https://github.com/willthames/ansible-lint) is a [linter](https://en.wikipedia.org/wiki/Lint_%28software%29) for ansible.
 
 #### ansible-toolkit
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,19 @@ The ansible tool itself.
 
 #### ansible-lint
 
-A linter for ansible.
+[Ansible-lint](https://github.com/willthames/ansible-lint) linter for ansible.
 
 #### ansible-toolkit
 
-A bundle of tracing, vault management, and other tools.
+[Ansible-toolkit](https://github.com/dellis23/ansible-toolkit) provides several tools to improve visibility and predictability of roles and vault management.
 
 #### test-kitchen, kitchen-vagrant, and kitchen-ansible
 
-Test Kitchen is a very popular infrastructure testing harness.
+[Test Kitchen](http://kitchen.ci) is a very popular infrastructure testing harness.
+
+#### Molecule
+
+[Molecule](https://github.com/metacloud/molecule) is a tool to ease (automated) testing for Ansible roles.
 
 #### AWS Support: kitchen-ec2, AWS cli, boto library, and jq
 

--- a/omnibus-ansible-dk/config/projects/ansible-dk.rb
+++ b/omnibus-ansible-dk/config/projects/ansible-dk.rb
@@ -27,6 +27,7 @@ override :'ansible-lint',    version: "2.1.3"
 override :'ansible-toolkit', version: "1.3.2"
 override :appbundler,        version: "0.6.0"
 override :serverspec,        version: "v2.24.2"
+override :molecule,          version: "1.0.5"
 
 
 # Creates required build directories
@@ -42,6 +43,7 @@ dependency "awscli"
 dependency "ansible"
 dependency "ansible-lint"
 dependency "ansible-toolkit"
+dependency "molecule"
 
 # Ruby land
 dependency "ruby"

--- a/omnibus-ansible-dk/config/software/molecule.rb
+++ b/omnibus-ansible-dk/config/software/molecule.rb
@@ -1,0 +1,16 @@
+name "molecule"
+default_version "1.0.5"
+
+dependency "python"
+dependency "pip"
+
+build do
+  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/embedded/bin\" #{name}==#{version}"
+
+  # This is an Officially Exposed Tool
+  [
+    'molecule',
+  ].each do |tool|      
+    link "#{install_dir}/embedded/bin/#{tool}", "#{install_dir}/bin"
+  end
+end


### PR DESCRIPTION
I'm not familiar with building omnibus-style, so this is just my first (untested) stab at including molecule into ansible-dk for Issue https://github.com/omniti-labs/ansible-dk/issues/40 

In particular, I would prefer ansible-dk should not pin to the version I have specified here, but instead follow the latest released version on PyPI. But the other examples seem to refer to following the master git branch not the latest release.
